### PR TITLE
feat: biginteger and decimal128 converter

### DIFF
--- a/backend/service/auction-service/build.gradle
+++ b/backend/service/auction-service/build.gradle
@@ -33,7 +33,6 @@ dependencyManagement {
 
 dependencies {
     // spring boot
-//	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/service/auction-service/src/main/java/shop/biday/config/ReactiveMongoConfig.java
+++ b/backend/service/auction-service/src/main/java/shop/biday/config/ReactiveMongoConfig.java
@@ -1,0 +1,26 @@
+package shop.biday.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
+import shop.biday.utils.BigIntegerToDecimal128Converter;
+import shop.biday.utils.Decimal128ToBigIntegerConverter;
+
+@Configuration
+@EnableReactiveMongoRepositories(basePackages = {
+        "shop.biday.model.repository"
+})
+public class ReactiveMongoConfig extends AbstractMongoClientConfiguration {
+
+    @Override
+    protected String getDatabaseName() {
+        return "bidaydb";
+    }
+
+    @Override
+    protected void configureConverters(MongoCustomConversions.MongoConverterConfigurationAdapter converterConfigurationAdapter) {
+        converterConfigurationAdapter.registerConverter(new BigIntegerToDecimal128Converter());
+        converterConfigurationAdapter.registerConverter(new Decimal128ToBigIntegerConverter());
+    }
+}

--- a/backend/service/auction-service/src/main/java/shop/biday/model/document/BidDocument.java
+++ b/backend/service/auction-service/src/main/java/shop/biday/model/document/BidDocument.java
@@ -6,6 +6,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
 
 import java.math.BigInteger;
 import java.time.LocalDateTime;
@@ -29,7 +30,7 @@ public class BidDocument {
     @Field(write = Write.ALWAYS)
     private String userId;
 
-    @Field(write = Write.ALWAYS)
+    @Field(write = Write.ALWAYS, targetType = FieldType.DECIMAL128)
     private BigInteger currentBid;
 
     @Builder.Default

--- a/backend/service/auction-service/src/main/java/shop/biday/utils/BigIntegerToDecimal128Converter.java
+++ b/backend/service/auction-service/src/main/java/shop/biday/utils/BigIntegerToDecimal128Converter.java
@@ -1,0 +1,19 @@
+package shop.biday.utils;
+
+import org.bson.types.Decimal128;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@Component
+@WritingConverter
+public class BigIntegerToDecimal128Converter implements Converter<BigInteger, Decimal128> {
+
+    @Override
+    public Decimal128 convert(BigInteger source) {
+        return Decimal128.parse(new BigDecimal(source).toPlainString());
+    }
+}

--- a/backend/service/auction-service/src/main/java/shop/biday/utils/Decimal128ToBigIntegerConverter.java
+++ b/backend/service/auction-service/src/main/java/shop/biday/utils/Decimal128ToBigIntegerConverter.java
@@ -1,0 +1,18 @@
+package shop.biday.utils;
+
+import org.bson.types.Decimal128;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+
+@Component
+@ReadingConverter
+public class Decimal128ToBigIntegerConverter implements Converter<Decimal128, BigInteger> {
+
+    @Override
+    public BigInteger convert(Decimal128 source) {
+        return source.bigDecimalValue().toBigInteger();
+    }
+}


### PR DESCRIPTION
### 입찰 정렬 문제 해결
mongodb는 biginteger 타입이 없어서 string으로 들어간다

- bigInteger -> Decimal128 converter 구현
- Decimal128 -> bigInteger converter 구현